### PR TITLE
Changed max vertical axis value in main forecast

### DIFF
--- a/tethysapp/streamflow_prediction_tool/controllers_ajax.py
+++ b/tethysapp/streamflow_prediction_tool/controllers_ajax.py
@@ -509,7 +509,8 @@ def get_ecmwf_hydrograph_plot(request):
         ),
         yaxis=dict(
             title='Streamflow ({}<sup>3</sup>/s)'
-                  .format(get_units_title(units))
+                  .format(get_units_title(units)),
+            range=[0, max(forecast_statistics['max'].values) + max(forecast_statistics['max'].values)/5]
         ),
         shapes=return_shapes,
         annotations=return_annotations


### PR DESCRIPTION
This is a small change but makes a lot of difference.

I noticed that the current SPT plot would use the default max return period as the max for the vertical axis value. This works fine when the forecast is near the return periods, but if it is a big river and the flow is not close to the return period, one cannot discern anything in the ensemble forecast. I changed the plot vertical max to be the max value from the max outer range forecast statistic plus a a fifth of it. For example, if the max is 100 then the max vertical axes value would be 100 + 100/5 =  120.

Here are the before and after pics:

![screen shot 2017-09-07 at 10 59 51 am](https://user-images.githubusercontent.com/17328135/30175779-3c38f2cc-93bd-11e7-8faa-c61b735eb22e.png)
 
![screen shot 2017-09-07 at 11 03 57 am](https://user-images.githubusercontent.com/17328135/30175807-501e8a22-93bd-11e7-98bd-1e493ebec652.png)

